### PR TITLE
change logic of checked property of input in theme toggler

### DIFF
--- a/src/components/ToggleThemeButton.tsx
+++ b/src/components/ToggleThemeButton.tsx
@@ -31,7 +31,7 @@ function ToggleThemeButton() {
         type="checkbox"
         value="light"
         className="toggle theme-controller"
-        checked={theme === "dark"}
+        checked={theme === "light"}
         onChange={toggleTheme}
       />
       <svg

--- a/src/components/ToggleThemeButton.tsx
+++ b/src/components/ToggleThemeButton.tsx
@@ -24,8 +24,7 @@ function ToggleThemeButton() {
         strokeLinecap="round"
         strokeLinejoin="round"
       >
-        <circle cx="12" cy="12" r="5" />
-        <path d="M12 1v2M12 21v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M1 12h2M21 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4" />
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
       </svg>
       <input
         type="checkbox"
@@ -34,6 +33,7 @@ function ToggleThemeButton() {
         checked={theme === "light"}
         onChange={toggleTheme}
       />
+
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="20"
@@ -45,7 +45,8 @@ function ToggleThemeButton() {
         strokeLinecap="round"
         strokeLinejoin="round"
       >
-        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+        <circle cx="12" cy="12" r="5" />
+        <path d="M12 1v2M12 21v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M1 12h2M21 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4" />
       </svg>
     </label>
   );


### PR DESCRIPTION
the local storage was 'wrongly' storing the state, for example, if the theme was 'light', in local storage it would save as 'dark' which necessarily isn't correct (was saving the opposite value)

this changes it so that if its dark, it saves as 'dark' and if its light, it saves as 'light'